### PR TITLE
Added Class-Module attributes to the export file, fixes #45

### DIFF
--- a/cls_Better_Access_Chart.cls
+++ b/cls_Better_Access_Chart.cls
@@ -1,3 +1,8 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "cls_Better_Access_Chart"
 Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False


### PR DESCRIPTION
When importing cls_Better_Access_Chart.cls into a fresh Access-Database, a new Module ("Modul1") is created.
Expected was the Import a new Class-Module.
Using this change the import will work as expected.